### PR TITLE
fix: DB 예약어 충돌 문제 해결

### DIFF
--- a/src/main/java/smash/teams/be/model/schedule/Schedule.java
+++ b/src/main/java/smash/teams/be/model/schedule/Schedule.java
@@ -17,10 +17,10 @@ public class Schedule {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User User;
+    private User user;
 
-    private String start;
-    private String end;
+    private String startDate;
+    private String endDate;
     private String type;
     private String status;
     private String reason;
@@ -41,11 +41,11 @@ public class Schedule {
 
 
     @Builder
-    public Schedule(Long id, smash.teams.be.model.user.User user, String start, String end, String type, String status, String reason, String master, LocalDateTime finishedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public Schedule(Long id, User user, String startDate, String endDate, String type, String status, String reason, String master, LocalDateTime finishedAt, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
-        User = user;
-        this.start = start;
-        this.end = end;
+        this.user = user;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.type = type;
         this.status = status;
         this.reason = reason;

--- a/src/main/java/smash/teams/be/model/team/Team.java
+++ b/src/main/java/smash/teams/be/model/team/Team.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Setter // DTO 만들면 삭제해야됨
 @Getter
-@Table(name = "schedule_tb")
+@Table(name = "team_tb")
 @Entity
 public class Team {
     @Id


### PR DESCRIPTION
**Background**
- 애플리케이션을 실행할 때 데이터베이스에 대해 실행하는 Create TABLE 쿼리에서 MySQL 예약어로 인해 충돌
관련 에러 로그 첨부합니다.
```
2023-05-03 00:20:07.677  WARN 4545 --- [  restartedMain] o.h.t.s.i.ExceptionHandlerLoggedImpl     : GenerationTarget encountered exception accepting command : Error executing DDL "
    create table schedule_tb (
       id bigint generated by default as identity,
        created_at timestamp,
        end varchar(255),
        finished_at timestamp,
        master varchar(255),
        reason varchar(255),
        start varchar(255),
        status varchar(255),
        type varchar(255),
        updated_at timestamp,
        user_id bigint,
        primary key (id)
    )" via JDBC Statement
```

관련 링크 : [https://dev.mysql.com/doc/refman/8.0/en/keywords.html](https://dev.mysql.com/doc/refman/8.0/en/keywords.html)

**Changes**
- Team 엔티티에 schedule_tb 테이블을 사용하도록 설정된 부분 team_tb 로 수정
- schedule_tb 테이블의 start 컬럼과 end  컬럼은 각각 start_date, end_date로 수정

