### PR TITLE
PR: Security Config 설정 변경, Team 관련 이름 변경

### DIFF
--- a/src/main/java/smash/teams/be/controller/AdminContoller.java
+++ b/src/main/java/smash/teams/be/controller/AdminContoller.java
@@ -5,29 +5,29 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 import smash.teams.be.dto.ResponseDTO;
-import smash.teams.be.dto.team.TeamRequest;
-import smash.teams.be.dto.team.TeamResponse;
-import smash.teams.be.service.TeamService;
+import smash.teams.be.dto.admin.AdminRequest;
+import smash.teams.be.dto.admin.AdminResponse;
+import smash.teams.be.service.AdminService;
 
 import javax.validation.Valid;
 
 @RequiredArgsConstructor
-@RequestMapping(("/auth/admin/team"))
+@RequestMapping(("/auth/admin"))
 @RestController
-public class TeamController {
-    private final TeamService teamService;
+public class AdminContoller {
+    private final AdminService adminService;
 
-    @PostMapping("/add")
-    public ResponseEntity<?> add(@RequestBody @Valid TeamRequest.AddInDTO addInDTO, Errors errors) {
-        TeamResponse.AddOutDTO addOutDTO = teamService.add(addInDTO); // OSIV = false, 비영속
+    @PostMapping("/team/add")
+    public ResponseEntity<?> add(@RequestBody @Valid AdminRequest.AddInDTO addInDTO, Errors errors) {
+        AdminResponse.AddOutDTO addOutDTO = adminService.add(addInDTO); // OSIV = false, 비영속
 
         ResponseDTO<?> responseDTO = new ResponseDTO<>(addOutDTO);
         return ResponseEntity.ok().body(responseDTO);
     }
 
-    @PostMapping("/{id}/delete")
+    @PostMapping("/team/{id}/delete")
     public ResponseEntity<?> delete(@PathVariable Long id) {
-        teamService.delete(id);
+        adminService.delete(id);
 
         ResponseDTO<?> responseDTO = new ResponseDTO<>();
         return ResponseEntity.ok().body(responseDTO);

--- a/src/main/java/smash/teams/be/core/config/SecurityConfig.java
+++ b/src/main/java/smash/teams/be/core/config/SecurityConfig.java
@@ -95,10 +95,10 @@ public class SecurityConfig {
     public CorsConfigurationSource configurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedHeader("*");
-        configuration.addAllowedMethod("GET, POST"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
+        configuration.addAllowedMethod("*"); // GET, POST, PUT, PATCH, DELETE (Javascript 요청 허용)
         configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용 (프론트 앤드 IP만 허용 react)
         configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
-        configuration.addExposedHeader("Authorization"); // 옛날에는 디폴트 였다. 지금은 아닙니다.
+        configuration.addExposedHeader("Authorization");
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/smash/teams/be/dto/admin/AdminRequest.java
+++ b/src/main/java/smash/teams/be/dto/admin/AdminRequest.java
@@ -1,4 +1,4 @@
-package smash.teams.be.dto.team;
+package smash.teams.be.dto.admin;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -7,7 +7,7 @@ import smash.teams.be.model.team.Team;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
-public class TeamRequest {
+public class AdminRequest {
     @Getter
     @Setter
     public static class AddInDTO {

--- a/src/main/java/smash/teams/be/dto/admin/AdminResponse.java
+++ b/src/main/java/smash/teams/be/dto/admin/AdminResponse.java
@@ -1,10 +1,10 @@
-package smash.teams.be.dto.team;
+package smash.teams.be.dto.admin;
 
 import lombok.Getter;
 import lombok.Setter;
 import smash.teams.be.model.team.Team;
 
-public class TeamResponse {
+public class AdminResponse {
     @Getter
     @Setter
     public static class AddOutDTO {

--- a/src/main/java/smash/teams/be/service/AdminService.java
+++ b/src/main/java/smash/teams/be/service/AdminService.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import smash.teams.be.core.exception.Exception400;
 import smash.teams.be.core.exception.Exception500;
-import smash.teams.be.dto.team.TeamRequest;
-import smash.teams.be.dto.team.TeamResponse;
+import smash.teams.be.dto.admin.AdminRequest;
+import smash.teams.be.dto.admin.AdminResponse;
 import smash.teams.be.model.team.Team;
 import smash.teams.be.model.team.TeamRepository;
 import smash.teams.be.model.user.UserRepository;
@@ -15,19 +15,19 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
-public class TeamService {
+public class AdminService {
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
 
     @Transactional
-    public TeamResponse.AddOutDTO add(TeamRequest.AddInDTO addInDTO) {
+    public AdminResponse.AddOutDTO add(AdminRequest.AddInDTO addInDTO) {
         Optional<Team> teamOP = teamRepository.findByTeamName(addInDTO.getTeamName());
         if (teamOP.isPresent()) {
             throw new Exception400(addInDTO.getTeamName(), "이미 존재하는 팀입니다.");
         }
         try {
             Team teamPS = teamRepository.save(addInDTO.toEntity());
-            return new TeamResponse.AddOutDTO(teamPS);
+            return new AdminResponse.AddOutDTO(teamPS);
         } catch (Exception e) {
             throw new Exception500("팀 추가 실패 : " + e.getMessage());
         }

--- a/src/test/java/smash/teams/be/controller/AdminContollerUnitTest.java
+++ b/src/test/java/smash/teams/be/controller/AdminContollerUnitTest.java
@@ -18,9 +18,9 @@ import smash.teams.be.core.advice.ValidAdvice;
 import smash.teams.be.core.config.FilterRegisterConfig;
 import smash.teams.be.core.config.SecurityConfig;
 import smash.teams.be.core.dummy.DummyEntity;
-import smash.teams.be.dto.team.TeamRequest;
-import smash.teams.be.dto.team.TeamResponse;
-import smash.teams.be.service.TeamService;
+import smash.teams.be.dto.admin.AdminRequest;
+import smash.teams.be.dto.admin.AdminResponse;
+import smash.teams.be.service.AdminService;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -41,28 +41,28 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 }) // Advice 와 Security 설정 가져오기
 @WebMvcTest(
         // 필요한 Controller 가져오기, 특정 필터를 제외하기
-        controllers = {TeamController.class}
+        controllers = {AdminContoller.class}
 )
-public class TeamControllerUnitTest extends DummyEntity {
+public class AdminContollerUnitTest extends DummyEntity {
 
     @Autowired
     private MockMvc mvc;
     @Autowired
     private ObjectMapper om;
     @MockBean
-    private TeamService teamService;
+    private AdminService adminService;
 
     @WithMockAdmin
     @Test
     public void add_test() throws Exception {
         // given
-        TeamRequest.AddInDTO addInDTO = new TeamRequest.AddInDTO();
+        AdminRequest.AddInDTO addInDTO = new AdminRequest.AddInDTO();
         addInDTO.setTeamName("마케팅팀");
         String requestBody = om.writeValueAsString(addInDTO);
 
         // stub
-        Mockito.when(teamService.add(any()))
-                .thenReturn(new TeamResponse.AddOutDTO(newMockTeam(3L, "마케팅팀")));
+        Mockito.when(adminService.add(any()))
+                .thenReturn(new AdminResponse.AddOutDTO(newMockTeam(3L, "마케팅팀")));
 
         // when
         ResultActions resultActions = mvc

--- a/src/test/java/smash/teams/be/service/AdminServiceTest.java
+++ b/src/test/java/smash/teams/be/service/AdminServiceTest.java
@@ -9,8 +9,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import smash.teams.be.core.dummy.DummyEntity;
-import smash.teams.be.dto.team.TeamRequest;
-import smash.teams.be.dto.team.TeamResponse;
+import smash.teams.be.dto.admin.AdminRequest;
+import smash.teams.be.dto.admin.AdminResponse;
 import smash.teams.be.model.team.TeamRepository;
 import smash.teams.be.model.user.UserRepository;
 
@@ -20,10 +20,10 @@ import static org.mockito.ArgumentMatchers.any;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
-public class TeamServiceTest extends DummyEntity {
+public class AdminServiceTest extends DummyEntity {
 
     @InjectMocks
-    private TeamService teamService;
+    private AdminService adminService;
     @Mock
     private TeamRepository teamRepository;
     @Mock
@@ -32,7 +32,7 @@ public class TeamServiceTest extends DummyEntity {
     @Test
     public void add_test() {
         // given
-        TeamRequest.AddInDTO addInDTO = new TeamRequest.AddInDTO();
+        AdminRequest.AddInDTO addInDTO = new AdminRequest.AddInDTO();
         addInDTO.setTeamName("회계팀");
 
         // stub 1
@@ -42,7 +42,7 @@ public class TeamServiceTest extends DummyEntity {
         Mockito.when(teamRepository.save(any())).thenReturn(newMockTeam(4L, "회계팀"));
 
         // when
-        TeamResponse.AddOutDTO addOutDTO = teamService.add(addInDTO);
+        AdminResponse.AddOutDTO addOutDTO = adminService.add(addInDTO);
 
         // then
         Assertions.assertThat(addOutDTO.getTeamId()).isEqualTo(4L);


### PR DESCRIPTION
## 작업 내용 (변경 사항)
configuration.addAllowedMethod가 모든 HTTP 메서드를 허용하도록 변경
TeamController -> AdminContoller
TeamService -> AdminService
TeamRequest -> AdminRequest
TeamResponse -> AdminResponse

## 스크린샷


## 테스트 결과


## 리뷰 요청 사항